### PR TITLE
include a startString option to child elements

### DIFF
--- a/.vscode/debug.js
+++ b/.vscode/debug.js
@@ -2,6 +2,6 @@ var bracket = require("../");
 
  //var b = new bracket.Parser("a {b {c}", {ignoreMissMatch: "{"}); 
 
-bracket("a [b {c", { ignoreMissMatch: ["[", "{"] });
+bracket("a {b \"{\" c}");
 //bracket("a [b (c d {d]", {ignoreMissMatch: ["(", "{"]});
 console.log("END");

--- a/README.md
+++ b/README.md
@@ -27,30 +27,33 @@ For more information on how to use this module, consult our [wiki](https://githu
 The result object will be an array of successfully closed brackets.  
 It will give details of the following on each successful closing bracket.
 
-| Property | Information 
-| -------: | :-----------
-| src      | The source string for the given result.
-| content  | The content inside the brackets.
-| start    | The starting index for the src string.  This relate to the string provided to parse through.
-| end      | The index of the last character of the src string.
-| lines    | The total amount of "\n" characters found in the src string.
-| closed   | Whether the current bracket has been sufficiently closed with a closing bracket (i.e. { -> needs } to be true).
-| match    | The matching data or data that is inside the brackets.
-| length   | The length of the src string.
+| Property | Type    | Information 
+| -------: | ------- | :-----------
+| src      | string  | The source string for the given result.
+| content  | string  | The content inside the brackets.
+| start    | integer | The starting index for the src string.  This relate to the string provided to parse through.
+| end      | integer | The index of the last character of the src string.
+| lines    | integer | The total amount of "\n" characters found in the src string.
+| closed   | boolean | Whether the current bracket has been sufficiently closed with a closing bracket (i.e. { -> needs } to be true).
+| match    | object  | The matching data or data that is inside the brackets.
+| length   | integer | The length of the src string.
 
 The matched item will in addition also have more detail regarding the match.  i.e:
 
-| Property     | Information
-| -----------: | ---------- 
-| contentStart | The index where the content will start excluding the brackets.
-| bracketStart | The index where the opening bracket will start (thus if the bracket.length = 1 this will be contentStart - 1)
-| start        | Might be different to bracketstart depending whether or not an opening bracket should have a prefix (i.e. #{ );
-| contentEnd   | This will also differ from normal end by the total length of the closing bracket (usually 1).
-| count        | The total number of "children" or child bracket have been found in this item.
-| children     | All the direct children objects (with same properties as this).  A child could be a closed bracket pair that is found inside the current item.
-| bracket      | Information of the bracket that caused the creation of this item.  i.e. what caused this item to be considered as opened or closed.
-| isPrefixed   | Determine if this item used a prefix in front of an opening bracket (i.e. #{ ).
-| prefixedChildren | Determine if any of the children used a prefix in front of an opening bracket.
+| Property     | Type    | Information
+| -----------: | ------- | ---------- 
+| startString  | string  | A string value that is directly in front of the bracket.
+| endString    | string  | A string value of the content that followed the last closing bracket of a child element.  This will mostly be an empty string, unless content follows the closing bracket.  Once again this is only applicable to child elements and not the resultSet.  Content that follows the last closing bracket in a resultSet will be ignored.
+| endStart     | integer | Index where the endString will start.
+| contentStart | integer | The index where the content will start excluding the brackets.
+| bracketStart | integer | The index where the opening bracket will start (thus if the bracket.length = 1 this will be contentStart - 1)
+| start        | integer | Might be different to bracketstart depending whether or not an opening bracket should have a prefix (i.e. #{ );
+| contentEnd   | integer | This will also differ from normal end by the total length of the closing bracket (usually 1).
+| count        | integer | The total number of "children" or child bracket have been found in this item.
+| children     | child[] | All the direct children objects (with same properties as this).  A child could be a closed bracket pair that is found inside the current item.
+| bracket      | object  | Information of the bracket that caused the creation of this item.  i.e. what caused this item to be considered as opened or closed.
+| isPrefixed   | boolean | Determine if this item used a prefix in front of an opening bracket (i.e. #{ ).
+| prefixedChildren | boolean | Determine if any of the children used a prefix in front of an opening bracket.
 
 
 ## Install

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=759670
+	// for the documentation about the jsconfig.json format
+	"compilerOptions": {
+		"target": "es6",
+		"module": "commonjs",
+		"allowSyntheticDefaultImports": true
+	},
+	"exclude": [
+		"node_modules",
+		"bower_components",
+		"jspm_packages",
+		"tmp",
+		"temp"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "g2-bracket-parser",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "Parse a JavaScript string to find conent in and arround brackets.",
   "main": "index.js",
   "scripts": {

--- a/test/spec/2. simpleSpec.js
+++ b/test/spec/2. simpleSpec.js
@@ -17,6 +17,7 @@ describe("A simplistic string tester", function(){
     it("should deal with a string inside brackets", function(){
         var results = bracket("this is {inside brackets}");
         var result = results[0];
+
         expect(results.length).toEqual(1);
         expect(result.src).toBe("this is {inside brackets}");
         expect(result.content).toBe("{inside brackets}");
@@ -28,7 +29,8 @@ describe("A simplistic string tester", function(){
         expect(result.prefixedChildren).toBe(false);
         expect(result.match.src).toBe("{inside brackets}");
         expect(result.match.content).toBe("inside brackets");
-        expect(result.match.prefixedBracket).toBe("{");
+        expect(result.match.startString).toBe("");
+        expect(result.match.endString).toBe("");
         expect(result.match.start).toEqual(8);
         expect(result.match.bracketStart).toEqual(8);
         expect(result.match.contentStart).toEqual(9);
@@ -46,6 +48,7 @@ describe("A simplistic string tester", function(){
         var result = results[0];
 
         expect(results.length).toEqual(1);
+
         expect(result.src).toBe("this is {inside brackets{inside brackets}}");
         expect(result.content).toBe("{inside brackets{inside brackets}}");
         expect(result.start).toEqual(0);
@@ -56,11 +59,16 @@ describe("A simplistic string tester", function(){
         expect(result.prefixedChildren).toBe(false);
         expect(result.match.src).toBe("{inside brackets{inside brackets}}");
         expect(result.match.content).toBe("inside brackets{inside brackets}");
-        expect(result.match.prefixedBracket).toBe("{");
+        expect(result.match.startString).toBe("");
+        expect(result.match.endString).toBe("");
+        expect(result.match.endStart).toEqual(result.match.contentEnd);
+
         expect(result.match.start).toEqual(8);
+        expect(result.match.prefixStart).toEqual(8);
         expect(result.match.bracketStart).toEqual(8);
         expect(result.match.contentStart).toEqual(9);
         expect(result.match.contentEnd).toEqual(40);
+        expect(result.match.endStart).toEqual(40);
         expect(result.match.end).toEqual(41);
         expect(result.match.lines).toEqual(1);
         expect(result.match.length).toEqual(34);
@@ -69,16 +77,17 @@ describe("A simplistic string tester", function(){
         expect(result.match.children.length).toEqual(result.match.count);
 
         var result = result.match.children[0];
-        expect(result.src).toBe("{inside brackets}");
+        expect(result.src).toBe("inside brackets{inside brackets}");
         expect(result.content).toBe("inside brackets");
-        expect(result.prefixedBracket).toBe("{");
-        expect(result.start).toEqual(24);
+        expect(result.startString).toBe("inside brackets");
+        expect(result.endString).toBe("");
+        expect(result.start).toEqual(9);
         expect(result.bracketStart).toEqual(24);
         expect(result.contentStart).toEqual(25);
         expect(result.contentEnd).toEqual(39);
         expect(result.end).toEqual(40);
         expect(result.lines).toEqual(1);
-        expect(result.length).toEqual(17);
+        expect(result.length).toEqual(32);
         expect(result.count).toEqual(0);
         expect(result.isPrefixed).toBe(false);
         expect(result.prefixedChildren).toBe(false);
@@ -104,25 +113,31 @@ describe("A simplistic string tester", function(){
         expect(result.match.length).toEqual(11);
 
         var result = result.match.children[0];
-        expect(result.src).toBe("{c {d}}");
+        expect(result.src).toBe("b {c {d}}");
+        expect(result.startString).toBe("b ");
+        expect(result.endString).toBe("");
         expect(result.content).toBe("c {d}");
-        expect(result.start).toEqual(5);
+        expect(result.start).toEqual(3);
         expect(result.bracketStart).toEqual(5);
         expect(result.contentStart).toEqual(6);
         expect(result.contentEnd).toEqual(10);
+        expect(result.endStart).toEqual(10);
         expect(result.end).toEqual(11);
-        expect(result.length).toEqual(7);
+        expect(result.length).toEqual(9);
 
         var result = result.children[0];
-        expect(result.src).toBe("{d}");
+        expect(result.src).toBe("c {d}");
         expect(result.content).toBe("d");
-        expect(result.start).toEqual(8);
+        expect(result.startString).toBe("c ")
+        expect(result.start).toEqual(6);
+        expect(result.prefixStart).toEqual(8);
         expect(result.bracketStart).toEqual(8);
         expect(result.contentStart).toEqual(9);
         expect(result.contentEnd).toEqual(9);
+        expect(result.endStart).toEqual(9);
         expect(result.end).toEqual(10);
         expect(result.lines).toEqual(1);
-        expect(result.length).toEqual(3);
+        expect(result.length).toEqual(5);
     });
     it("should deal with a string with 2 main brackets", function(){
         var results = bracket("a {b {c} d} e {f} g");
@@ -137,22 +152,31 @@ describe("A simplistic string tester", function(){
 
         expect(result.match.src).toBe("{b {c} d}");
         expect(result.match.content).toBe("b {c} d");
+        expect(result.match.endString).toBe(" d");
+        expect(result.match.startString).toBe("");
         expect(result.match.start).toEqual(2);
+        expect(result.match.prefixStart).toEqual(2);
         expect(result.match.bracketStart).toEqual(2);
         expect(result.match.contentStart).toEqual(3);
         expect(result.match.contentEnd).toEqual(9);
         expect(result.match.end).toEqual(10);
+        expect(result.match.endStart).toEqual(8);
         expect(result.match.length).toEqual(9);
+        expect(result.match.children.length).toEqual(1);
+        expect(result.match.count).toEqual(1);
 
         var result = result.match.children[0];
-        expect(result.src).toBe("{c}");
+        expect(result.src).toBe("b {c}");
         expect(result.content).toBe("c");
-        expect(result.start).toEqual(5);
+        expect(result.startString).toBe("b ");
+        expect(result.endString).toBe("");
+        expect(result.start).toEqual(3);
         expect(result.bracketStart).toEqual(5);
         expect(result.contentStart).toEqual(6);
         expect(result.contentEnd).toEqual(6);
         expect(result.end).toEqual(7);
-        expect(result.length).toEqual(3);
+        expect(result.endStart).toEqual(6);
+        expect(result.length).toEqual(5);
 
         var result = results[1];
         expect(results.length).toEqual(2);
@@ -182,29 +206,35 @@ describe("A simplistic string tester", function(){
         expect(result.match.end).toEqual(16);
         expect(result.match.length).toEqual(15);
         expect(result.match.count).toEqual(2);
+        expect(result.match.endString).toEqual(" f");
+        expect(result.match.endStart).toEqual(14);
 
         var result = result.match.children[0];
-        expect(result.src).toBe("{c}");
+        expect(result.src).toBe("b {c}");
+        expect(result.startString).toBe("b ");
         expect(result.content).toBe("c");
-        expect(result.start).toEqual(5);
+        expect(result.endString).toBe("");
+        expect(result.start).toEqual(3);
         expect(result.bracketStart).toEqual(5);
         expect(result.contentStart).toEqual(6);
         expect(result.contentEnd).toEqual(6);
         expect(result.end).toEqual(7);
-        expect(result.length).toEqual(3);
+        expect(result.length).toEqual(5);
 
         var result = results[0].match.children[1];
-        expect(result.src).toBe("{e}");
+        expect(result.src).toBe(" d {e}");
+        expect(result.startString).toBe(" d ");
         expect(result.content).toBe("e");
-        expect(result.start).toEqual(11);
+        expect(result.start).toEqual(8);
         expect(result.bracketStart).toEqual(11);
         expect(result.contentStart).toEqual(12);
         expect(result.contentEnd).toEqual(12);
         expect(result.end).toEqual(13);
-        expect(result.length).toEqual(3);
+        expect(result.length).toEqual(6);
     });
     it("should ignore by default any brackets inside of single or double quotes", function(){
         var result = bracket("a '{' b");
+
         expect(function(){ bracket("a '{' c"); }).not.toThrowError();
         expect(result.length).toEqual(0);
         result = bracket("a {b '{' c}");

--- a/test/spec/3. complexSpec.js
+++ b/test/spec/3. complexSpec.js
@@ -29,6 +29,7 @@ describe("Testing complex string queries", function(){
         it("should stop closing brackets testing if new line symbol is found", function(){
             complex.options.brackets = {"{":{start:"{", end:"test}", length: 1}};
             var result = complex.newLines("a {b test\n}test}", complex.options)[0];
+
             expect(result.lines).toEqual(2);
             expect(result.content).toBe("{b test\n}test}");
 
@@ -205,6 +206,7 @@ describe("Testing complex string queries", function(){
         it("should close required bracket if found inside a miss match type", function(){
             complex.options.ignoreMissMatch = ["{", "("];
             var results = complex.miss("a [b (c d] {d {e", complex.options);
+
             expect(results[0].src).toBe("a [b (c d]");
             expect(results[0].content).toBe("[b (c d]")
             expect(results[0].match.src).toBe("[b (c d]");
@@ -222,7 +224,8 @@ describe("Testing complex string queries", function(){
             expect(results[1].match.content).toBe("d {e");
 
             expect(results[1].match.child.count).toEqual(0);
-            expect(results[1].match.child.src).toBe("{e");
+            expect(results[1].match.child.startString).toBe("d ")
+            expect(results[1].match.child.src).toBe("d {e");
             expect(results[1].match.child.content).toBe("e");
     
             expect(results[1].closed).toBeFalsy();
@@ -234,6 +237,7 @@ describe("Testing complex string queries", function(){
             complex.options.autoComplete = false;
 
             var results = complex.miss("a [b (c d] {d {e ", complex.options);
+
             expect(results[0].src).toBe("a [b (c d]");
             expect(results[0].match.src).toBe("[b (c d]");
             expect(results[0].match.children.length).toEqual(1);
@@ -247,11 +251,13 @@ describe("Testing complex string queries", function(){
             expect(results[1].match.count).toEqual(0);
             expect(results[1].match.children.length).toEqual(0);
             expect(results[1].match.src).toBe("{");
-            expect(results[1].match.content).toBe("d ");
+            expect(results[1].match.content).toBe("");
             expect(results[1].closed).toBeFalsy();
             expect(results[1].match.closed).toBeFalsy();
-            expect(results[1].match.child.content).toBe("e ");
-            expect(results[1].match.child.src).toBe("{")
+            expect(results[1].match.child.startString).toBe("d ");
+            expect(results[1].match.child.endString).toBe("e ");
+            expect(results[1].match.child.content).toBe("");
+            expect(results[1].match.child.src).toBe("d {")
             expect(results[1].match.child.count).toEqual(0);
         });
 


### PR DESCRIPTION
Structural change to resulting children.  Children will now have an optional startString value and endString value.
